### PR TITLE
Force use of option.value in Single and Multiple Choice types

### DIFF
--- a/src/core/__tests__/types/index.spec.ts
+++ b/src/core/__tests__/types/index.spec.ts
@@ -157,12 +157,32 @@ describe('MultipleChoice', () => {
       expect(await transform(['word', 123, '123'], rule)).toEqual(['word', 123]);
     });
 
-    test('returning label', async () => {
+    test(`returning value even if it is falsy`, async () => {
+      const rule = mocks.Rule({
+        options: [
+          mocks.RuleOption({
+            label: 'null',
+            value: null,
+          }),
+          mocks.RuleOption({
+            label: 'false',
+            value: false,
+          }),
+          mocks.RuleOption({
+            label: 'empty-string',
+            value: '',
+          }),
+        ],
+      });
+      expect(await transform([null, 'dog', false, 123, ''], rule)).toEqual([null, false, '']);
+    });
+
+    test('returning label if value is undefined', async () => {
       const rule = mocks.Rule({
         options: [
           mocks.RuleOption({
             label: 'The Word',
-            value: null,
+            value: undefined,
           }),
         ],
       });

--- a/src/core/__tests__/types/index.spec.ts
+++ b/src/core/__tests__/types/index.spec.ts
@@ -58,12 +58,26 @@ describe('SingleChoice', () => {
       expect(await transform('word', rule)).toBe('word');
     });
 
-    test('returning label', async () => {
+    [null, false, ''].forEach(value => {
+      test(`returning value even if it is "${value}"`, async () => {
+        const rule = mocks.Rule({
+          options: [
+            mocks.RuleOption({
+              label: 'The Word',
+              value,
+            }),
+          ],
+        });
+        expect(await transform('The Word', rule)).toBe(value);
+      });
+    });
+
+    test('returning label if value is undefined', async () => {
       const rule = mocks.Rule({
         options: [
           mocks.RuleOption({
             label: 'The Word',
-            value: null,
+            value: undefined,
           }),
         ],
       });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -70,9 +70,9 @@ const types: { [name: string]: IRuleType } = {
             if (!option) {
               return undefined;
             }
-            return option.value || option.label;
+            return option.value === undefined ? option.label : option.value;
           })
-          .filter((x) => x));
+          .filter((x) => x !== undefined));
       },
       validators: [
         {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -36,7 +36,7 @@ const types: { [name: string]: IRuleType } = {
         if (!option) {
           return undefined;
         }
-        return option.value || option.label;
+        return option.value === undefined ? option.label : option.value;
       },
       validators: [
         {


### PR DESCRIPTION
Only use `option.label` if `value` is `undefined`

- [x] SingleChoice
- [x] MultipleChoice

fixes #76 